### PR TITLE
Document why this repo omits the OpenTofu Tests badge

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,8 @@
 # pt-techne-opentofu-workflows
 
 Reusable GitHub Actions called workflows for OpenTofu deployments across all platform repos. Handles OIDC authentication, state backend configuration, plan/apply job summaries, and Workload Identity Federation.
+
+## README Badges
+
+The platform README badge convention says to add an "OpenTofu Tests" badge whenever a `test.yml` workflow exists. This repo intentionally **does not** include that badge: `test.yml` here is a reusable called workflow consumed by other repos (the `tofu test` runner), not a local CI test of this repo. Its run history reflects callers, not this repo, so the badge would be misleading.
+


### PR DESCRIPTION
The platform README badge convention says to add an OpenTofu Tests badge whenever a `test.yml` workflow exists. This repo's `test.yml` is a **reusable called workflow** consumed by other repos (the `tofu test` runner) — not a local CI test of this repo. Its run history reflects callers, not this repo, so the badge would be misleading.

Records the exception in `.github/copilot-instructions.md` so future audits don't flag it again.

No README change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository documentation to clarify information about test workflow configuration and related badge implementation decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->