### PR TITLE
Add -json-into flag and upload JSON artifacts for plan and apply

### DIFF
--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -146,7 +146,7 @@ jobs:
       - name: OpenTofu plan
         id: plan
         run: |
-          tofu plan -detailed-exitcode -input=false -out=plan.out ${{ inputs.opentofu_plan_args }} ${{ secrets.opentofu_plan_secret_args }}
+          tofu plan -detailed-exitcode -input=false -out=plan.out -json-into=plan.json ${{ inputs.opentofu_plan_args }} ${{ secrets.opentofu_plan_secret_args }}
 
       - name: OpenTofu show
         id: show
@@ -163,6 +163,15 @@ jobs:
             core.summary
               .addCodeBlock(tofuOutput, 'hcl')
               .write();
+
+      # GitHub - Upload Artifact
+      # https://github.com/marketplace/actions/upload-a-build-artifact
+
+      - name: Upload plan JSON
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: opentofu-plan-${{ inputs.opentofu_workspace }}
+          path: ${{ inputs.working_directory }}/plan.json
 
     outputs:
       plan-exit-code: ${{ steps.plan.outputs.exitcode }}
@@ -231,7 +240,7 @@ jobs:
 
       - name: OpenTofu apply
         id: apply
-        run: tofu apply -no-color plan.out
+        run: tofu apply -no-color -json-into=apply.json plan.out
 
       - name: OpenTofu summary
         continue-on-error: true
@@ -244,3 +253,12 @@ jobs:
             core.summary
               .addCodeBlock(tofuOutput, 'hcl')
               .write();
+
+      # GitHub - Upload Artifact
+      # https://github.com/marketplace/actions/upload-a-build-artifact
+
+      - name: Upload apply JSON
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: opentofu-apply-${{ inputs.opentofu_workspace }}
+          path: ${{ inputs.working_directory }}/apply.json

--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -172,6 +172,7 @@ jobs:
         with:
           name: opentofu-plan-${{ inputs.opentofu_workspace }}
           path: ${{ inputs.working_directory }}/plan.json
+          retention-days: 7
 
     outputs:
       plan-exit-code: ${{ steps.plan.outputs.exitcode }}
@@ -262,3 +263,4 @@ jobs:
         with:
           name: opentofu-apply-${{ inputs.opentofu_workspace }}
           path: ${{ inputs.working_directory }}/apply.json
+          retention-days: 7

--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -168,7 +168,7 @@ jobs:
       # https://github.com/marketplace/actions/upload-a-build-artifact
 
       - name: Upload plan JSON
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: opentofu-plan-${{ inputs.opentofu_workspace }}
           path: ${{ inputs.working_directory }}/plan.json
@@ -258,7 +258,7 @@ jobs:
       # https://github.com/marketplace/actions/upload-a-build-artifact
 
       - name: Upload apply JSON
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: opentofu-apply-${{ inputs.opentofu_workspace }}
           path: ${{ inputs.working_directory }}/apply.json

--- a/tests/plan-and-apply/environments/non-production.tfvars
+++ b/tests/plan-and-apply/environments/non-production.tfvars
@@ -1,2 +1,2 @@
-project                                 = "pt-techne-testing-tf65-nonprod"
+project                                 = "pt-techne-tfb0-nonprod"
 project_cis_2_2_logging_sink_project_id = "pt-corpus-tf61-nonprod"

--- a/tests/plan-and-apply/environments/production.tfvars
+++ b/tests/plan-and-apply/environments/production.tfvars
@@ -1,2 +1,2 @@
-project                                 = "pt-techne-testing-tf6a-prod"
+project                                 = "pt-techne-tf09-prod"
 project_cis_2_2_logging_sink_project_id = "pt-corpus-tf16-prod"

--- a/tests/plan-and-apply/environments/sandbox.tfvars
+++ b/tests/plan-and-apply/environments/sandbox.tfvars
@@ -1,2 +1,2 @@
-project                                 = "pt-techne-testing-tf0d-sb"
+project                                 = "pt-techne-tfdf-sb"
 project_cis_2_2_logging_sink_project_id = "pt-corpus-tfc9-sb"


### PR DESCRIPTION
Leverages the OpenTofu v1.12.0 `-json-into=FILENAME` flag, which writes machine-readable JSON output to a file while the normal human-readable UI output continues on stdout.

Both the plan and apply steps now produce a JSON artifact uploaded to GitHub Actions:
- `opentofu-plan-<workspace>` — machine-readable plan JSON
- `opentofu-apply-<workspace>` — machine-readable apply JSON

This enables downstream tooling (cost estimation, security scanning, audit trails) to consume structured output without replacing the existing human-readable job summaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow now emits plan and apply results in JSON and archives them as downloadable artifacts per run.

* **Tests**
  * Test environment configurations updated with new project identifiers for production, non-production, and sandbox to align with current test targets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-techne-opentofu-workflows/pull/225)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->