### PR TITLE
Restrict dangerous workflow triggers and fix over-permissive GITHUB_TOKEN

### DIFF
--- a/.github/workflows/local-dependabot.yml
+++ b/.github/workflows/local-dependabot.yml
@@ -1,9 +1,11 @@
 name: Dependabot Approve and Merge
 
-on: pull_request_target
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 permissions:
-  pull-requests: write
+  contents: read
 
 jobs:
   dependabot:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -16,6 +16,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  actions: read
   contents: read
   id-token: write
 


### PR DESCRIPTION
## Summary

Hardens two workflow files against security risks from `pull_request_target` and `workflow_run` triggers.

### `local-dependabot.yml`
- Adds explicit `types: [opened, synchronize, reopened]` to the `pull_request_target` trigger (already the implicit default; making it explicit documents intent)
- **Fixes over-permissive `GITHUB_TOKEN`**: changes `pull-requests: write` → `contents: read`. The reusable workflow uses a GitHub App token (via `actions/create-github-app-token`) for all privileged operations (PR approve and merge), not `GITHUB_TOKEN`. Granting `pull-requests: write` to `GITHUB_TOKEN` at the caller level is therefore unnecessary and violates least-privilege.

### `production.yml`
- Adds `actions: read` to the `permissions` block — best practice when reading `workflow_run` event context

Existing mitigations on `production.yml` remain in place: `branches: [main]` scope restriction, `conclusion == 'success'` check, OIDC-based GCP authentication.
