### PR TITLE
Simplify plan summary to show totals only

### DIFF
--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -145,12 +145,9 @@ jobs:
 
       - name: OpenTofu plan
         id: plan
-        run: |
-          set +e
-          tofu plan -detailed-exitcode -input=false -out=plan.out ${{ inputs.opentofu_plan_args }} ${{ secrets.opentofu_plan_secret_args }}
-          exitcode=$?
-          echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
-          if [ $exitcode -eq 1 ]; then exit 1; fi
+        run: >-
+          tofu plan -detailed-exitcode -input=false -out=plan.out
+          ${{ inputs.opentofu_plan_args }} ${{ secrets.opentofu_plan_secret_args }}
 
       - name: OpenTofu show
         id: show
@@ -186,7 +183,7 @@ jobs:
   apply:
     name: OpenTofu apply
     needs: plan
-    if: needs.plan.outputs.plan-exit-code == '2'
+    if: needs.plan.outputs.plan-exit-code == 2
     runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.github_environment }}

--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -149,6 +149,14 @@ jobs:
           tofu plan -detailed-exitcode -input=false -out=plan.out
           ${{ inputs.opentofu_plan_args }} ${{ secrets.opentofu_plan_secret_args }}
 
+      - name: Debug plan outputs
+        if: always()
+        run: |
+          echo "exitcode output = ${{ steps.plan.outputs.exitcode }}"
+          echo "outcome = ${{ steps.plan.outcome }}"
+          echo "conclusion = ${{ steps.plan.conclusion }}"
+          cat "$GITHUB_OUTPUT" || true
+
       - name: OpenTofu show
         id: show
         run: tofu show -no-color plan.out | tee "$RUNNER_TEMP/tofu-show.txt"

--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -170,7 +170,8 @@ jobs:
             const errorMatch = output.match(/Error:.+/);
             const lines = [];
             if (planMatch) {
-              lines.push(`**${planMatch[0]}**`, '');
+              lines.push('| ➕ Add | 🔄 Change | 🗑️ Destroy |', '|---|---|---|');
+              lines.push(`| ${planMatch[1]} | ${planMatch[2]} | ${planMatch[3]} |`, '');
             } else if (!errorMatch) {
               lines.push('**✅ No changes.** Your infrastructure matches the configuration.', '');
             }

--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -261,12 +261,30 @@ jobs:
             const logo = '<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/opentofu/brand-artifacts/main/full/transparent/PNG/on-dark.png"><img src="https://raw.githubusercontent.com/opentofu/brand-artifacts/main/full/transparent/PNG/on-light.png" height="24"></picture>';
             const lines = [logo, ''];
             if (applyMatch) {
-              lines.push('| ➕ Add | 🔄 Change | 🗑️ Destroy |', '|---|---|---|');
-              lines.push(`| ${applyMatch[1]} | ${applyMatch[2]} | ${applyMatch[3]} |`, '');
-            } else if (!errorMatch) {
-              lines.push('**✅ No changes.** Your infrastructure matches the configuration.', '');
+              lines.push(`**✅ Apply complete!** ${applyMatch[1]} added, ${applyMatch[2]} changed, ${applyMatch[3]} destroyed.`, '');
+            } else if (errorMatch) {
+              const succeeded = (output.match(/Creation complete/g) || []).length
+                + (output.match(/Modifications complete/g) || []).length
+                + (output.match(/Destruction complete/g) || []).length;
+              const failed = (output.match(/Error:/g) || []).length;
+              lines.push(`**❌ Apply failed.** ${succeeded} succeeded, ${failed} errored.`, '');
+              lines.push(`> ${errorMatch[0]}`, '');
             }
-            if (errorMatch) { lines.push(`> ❌ ${errorMatch[0]}`, ''); }
+            const outputsStart = output.indexOf('\nOutputs:\n');
+            if (outputsStart !== -1) {
+              const outputEntries = [];
+              for (const line of output.slice(outputsStart + '\nOutputs:\n'.length).trim().split('\n')) {
+                const m = line.match(/^(\S+)\s*=\s*(.+)$/);
+                if (m) outputEntries.push({ name: m[1], value: m[2].trim() });
+              }
+              if (outputEntries.length) {
+                lines.push('**Outputs**', '', '| Name | Value |', '|---|---|');
+                for (const { name, value } of outputEntries) {
+                  lines.push(`| \`${name}\` | \`${value}\` |`);
+                }
+                lines.push('');
+              }
+            }
             lines.push('<details>', '<summary>Full Apply Output</summary>', '', '```hcl', output, '```', '', '</details>');
             await core.summary.addRaw(lines.join('\n')).write();
 

--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -149,14 +149,6 @@ jobs:
           tofu plan -detailed-exitcode -input=false -out=plan.out
           ${{ inputs.opentofu_plan_args }} ${{ secrets.opentofu_plan_secret_args }}
 
-      - name: Debug plan outputs
-        if: always()
-        run: |
-          echo "exitcode output = ${{ steps.plan.outputs.exitcode }}"
-          echo "outcome = ${{ steps.plan.outcome }}"
-          echo "conclusion = ${{ steps.plan.conclusion }}"
-          cat "$GITHUB_OUTPUT" || true
-
       - name: OpenTofu show
         id: show
         run: tofu show -no-color plan.out | tee "$RUNNER_TEMP/tofu-show.txt"

--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -145,9 +145,12 @@ jobs:
 
       - name: OpenTofu plan
         id: plan
+        env:
+          OPENTOFU_PLAN_ARGS: ${{ inputs.opentofu_plan_args }}
+          OPENTOFU_PLAN_SECRET_ARGS: ${{ secrets.opentofu_plan_secret_args }}
         run: >-
           tofu plan -detailed-exitcode -input=false -out=plan.out
-          ${{ inputs.opentofu_plan_args }} ${{ secrets.opentofu_plan_secret_args }}
+          $OPENTOFU_PLAN_ARGS $OPENTOFU_PLAN_SECRET_ARGS
 
       - name: OpenTofu show
         id: show

--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -168,7 +168,8 @@ jobs:
             if (!output.trim()) { return; }
             const planMatch = output.match(/Plan: (\d+) to add, (\d+) to change, (\d+) to destroy/);
             const errorMatch = output.match(/Error:.+/);
-            const lines = [];
+            const logo = '<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/opentofu/brand-artifacts/main/full/transparent/PNG/on-dark.png"><img src="https://raw.githubusercontent.com/opentofu/brand-artifacts/main/full/transparent/PNG/on-light.png" height="24"></picture>';
+            const lines = [logo, ''];
             if (planMatch) {
               lines.push('| ➕ Add | 🔄 Change | 🗑️ Destroy |', '|---|---|---|');
               lines.push(`| ${planMatch[1]} | ${planMatch[2]} | ${planMatch[3]} |`, '');
@@ -280,7 +281,8 @@ jobs:
             const actionOrder = { destroyed: 0, changed: 1, added: 2 };
             const actionLabel = { added: '➕ Add', changed: '🔄 Change', destroyed: '🗑️ Destroy' };
             const rows = Object.entries(started).sort(([, a], [, b]) => actionOrder[a] - actionOrder[b]);
-            const lines = [];
+            const logo = '<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/opentofu/brand-artifacts/main/full/transparent/PNG/on-dark.png"><img src="https://raw.githubusercontent.com/opentofu/brand-artifacts/main/full/transparent/PNG/on-light.png" height="24"></picture>';
+            const lines = [logo, ''];
             if (rows.length) {
               lines.push('| Action | Resource | Duration | Status |', '|---|---|---|---|');
               for (const [r, action] of rows) {

--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -186,7 +186,7 @@ jobs:
   apply:
     name: OpenTofu apply
     needs: plan
-    if: needs.plan.outputs.plan-exit-code == 2
+    if: needs.plan.outputs.plan-exit-code == '2'
     runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.github_environment }}

--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -166,49 +166,12 @@ jobs:
             const outputFile = `${process.env.RUNNER_TEMP}/tofu-show.txt`;
             const output = fs.existsSync(outputFile) ? fs.readFileSync(outputFile, 'utf8') : '';
             if (!output.trim()) { return; }
-            const escape = (s) => String(s).replace(/[`|\\]/g, '\\$&');
-            const cell = (s) => escape(String(s).replace(/\r?\n/g, '\\n'));
             const planMatch = output.match(/Plan: (\d+) to add, (\d+) to change, (\d+) to destroy/);
             const errorMatch = output.match(/Error:.+/);
-            const toAdd = [], toChange = [], toDestroy = [];
-            for (const line of output.split('\n')) {
-              const m = line.match(/# (\S+) will be (created|destroyed|updated in-place)/);
-              const r = line.match(/# (\S+).*must be replaced/);
-              if (m) {
-                if (m[2] === 'created') toAdd.push(m[1]);
-                else if (m[2] === 'destroyed') toDestroy.push(m[1]);
-                else if (m[2] === 'updated in-place') toChange.push(m[1]);
-              } else if (r) { toChange.push(r[1]); }
-            }
-            const outputChanges = [];
-            const outputsIdx = output.indexOf('Changes to Outputs:');
-            if (outputsIdx !== -1) {
-              const block = output.slice(outputsIdx + 'Changes to Outputs:'.length);
-              for (const line of block.split('\n')) {
-                if (!line.trim()) continue;
-                const m = line.match(/^\s+([+~-])\s+(\S+)\s*=\s*(.+)$/);
-                if (!m) break;
-                const icon = m[1] === '+' ? '➕' : m[1] === '-' ? '🗑️' : '🔄';
-                outputChanges.push({ icon, name: m[2], value: m[3].trim() });
-              }
-            }
             const lines = ['#### 🔨 OpenTofu Plan', ''];
-            if (toDestroy.length || toChange.length || toAdd.length) {
-              lines.push('| Action | Resource |', '|---|---|');
-              for (const r of toDestroy) lines.push(`| 🗑️ Destroy | \`${escape(r)}\` |`);
-              for (const r of toChange)  lines.push(`| 🔄 Change  | \`${escape(r)}\` |`);
-              for (const r of toAdd)     lines.push(`| ➕ Add     | \`${escape(r)}\` |`);
-              lines.push('');
-            }
-            if (outputChanges.length) {
-              lines.push('**📤 Output changes**', '');
-              lines.push('| Action | Output | Value |', '|---|---|---|');
-              for (const { icon, name, value } of outputChanges) {
-                lines.push(`| ${icon} | \`${escape(name)}\` | \`${cell(value)}\` |`);
-              }
-              lines.push('');
-            }
-            if (!planMatch && !errorMatch && !outputChanges.length) {
+            if (planMatch) {
+              lines.push(`**${planMatch[0]}**`, '');
+            } else if (!errorMatch) {
               lines.push('**✅ No changes.** Your infrastructure matches the configuration.', '');
             }
             if (errorMatch) { lines.push(`> ❌ ${errorMatch[0]}`, ''); }

--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -168,7 +168,7 @@ jobs:
             if (!output.trim()) { return; }
             const planMatch = output.match(/Plan: (\d+) to add, (\d+) to change, (\d+) to destroy/);
             const errorMatch = output.match(/Error:.+/);
-            const lines = ['#### 🔨 OpenTofu Plan', ''];
+            const lines = [];
             if (planMatch) {
               lines.push(`**${planMatch[0]}**`, '');
             } else if (!errorMatch) {
@@ -279,7 +279,7 @@ jobs:
             const actionOrder = { destroyed: 0, changed: 1, added: 2 };
             const actionLabel = { added: '➕ Add', changed: '🔄 Change', destroyed: '🗑️ Destroy' };
             const rows = Object.entries(started).sort(([, a], [, b]) => actionOrder[a] - actionOrder[b]);
-            const lines = ['#### 🚀 OpenTofu Apply', ''];
+            const lines = [];
             if (rows.length) {
               lines.push('| Action | Resource | Duration | Status |', '|---|---|---|---|');
               for (const [r, action] of rows) {

--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -256,59 +256,17 @@ jobs:
             const outputFile = `${process.env.RUNNER_TEMP}/tofu-apply.txt`;
             const output = fs.existsSync(outputFile) ? fs.readFileSync(outputFile, 'utf8') : '';
             if (!output.trim()) { return; }
-            const escape = (s) => String(s).replace(/[`|\\]/g, '\\$&');
-            const cell = (s) => escape(String(s).replace(/\r?\n/g, '\\n'));
             const applyMatch = output.match(/Apply complete! Resources: (\d+) added, (\d+) changed, (\d+) destroyed/);
             const errorMatch = output.match(/Error:.+/);
-            const started = {}, completed = new Set(), durations = {};
-            for (const line of output.split('\n')) {
-              const creating   = line.match(/^(.+): Creating\.\.\./);
-              const modifying  = line.match(/^(.+): Modifying\.\.\./);
-              const destroying = line.match(/^(.+): Destroying\.\.\./);
-              const created    = line.match(/^(.+): Creation complete after (\S+)/);
-              const modified   = line.match(/^(.+): Modifications complete after (\S+)/);
-              const destroy    = line.match(/^(.+): Destruction complete after (\S+)/);
-              if (creating)   started[creating[1].trim()]   = 'added';
-              if (modifying)  started[modifying[1].trim()]  = 'changed';
-              if (destroying) started[destroying[1].trim()] = 'destroyed';
-              if (created)  { completed.add(created[1].trim());  durations[created[1].trim()]  = created[2]; }
-              if (modified) { completed.add(modified[1].trim()); durations[modified[1].trim()] = modified[2]; }
-              if (destroy)  { completed.add(destroy[1].trim());  durations[destroy[1].trim()]  = destroy[2]; }
-            }
-            const actionOrder = { destroyed: 0, changed: 1, added: 2 };
-            const actionLabel = { added: '➕ Add', changed: '🔄 Change', destroyed: '🗑️ Destroy' };
-            const rows = Object.entries(started).sort(([, a], [, b]) => actionOrder[a] - actionOrder[b]);
             const logo = '<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/opentofu/brand-artifacts/main/full/transparent/PNG/on-dark.png"><img src="https://raw.githubusercontent.com/opentofu/brand-artifacts/main/full/transparent/PNG/on-light.png" height="24"></picture>';
             const lines = [logo, ''];
-            if (rows.length) {
-              lines.push('| Action | Resource | Duration | Status |', '|---|---|---|---|');
-              for (const [r, action] of rows) {
-                const ok  = completed.has(r);
-                const dur = durations[r] ? escape(durations[r]) : '—';
-                lines.push(`| ${actionLabel[action]} | \`${escape(r)}\` | ${dur} | ${ok ? '✅' : '❌'} |`);
-              }
-              lines.push('');
-            }
-            if (!applyMatch && !errorMatch && !rows.length) {
+            if (applyMatch) {
+              lines.push('| ➕ Add | 🔄 Change | 🗑️ Destroy |', '|---|---|---|');
+              lines.push(`| ${applyMatch[1]} | ${applyMatch[2]} | ${applyMatch[3]} |`, '');
+            } else if (!errorMatch) {
               lines.push('**✅ No changes.** Your infrastructure matches the configuration.', '');
             }
             if (errorMatch) { lines.push(`> ❌ ${errorMatch[0]}`, ''); }
-            const outputsStart = output.indexOf('\nOutputs:\n');
-            if (outputsStart !== -1) {
-              const outputEntries = [];
-              for (const line of output.slice(outputsStart + '\nOutputs:\n'.length).trim().split('\n')) {
-                const m = line.match(/^(\S+)\s*=\s*(.+)$/);
-                if (m) outputEntries.push({ name: m[1], value: m[2].trim() });
-              }
-              if (outputEntries.length) {
-                lines.push('**Outputs**', '');
-                lines.push('| Name | Value |', '|---|---|');
-                for (const { name, value } of outputEntries) {
-                  lines.push(`| \`${escape(name)}\` | \`${cell(value)}\` |`);
-                }
-                lines.push('');
-              }
-            }
             lines.push('<details>', '<summary>Full Apply Output</summary>', '', '```hcl', output, '```', '', '</details>');
             await core.summary.addRaw(lines.join('\n')).write();
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,7 @@ jobs:
               if (fileMatch) currentFile = fileMatch[1];
               if (runMatch && currentFile) runs.push({ file: currentFile, run: runMatch[1], result: runMatch[2] });
             }
-            const lines = ['#### 🔨 OpenTofu Test', ''];
+            const lines = [];
             if (runs.length) {
               lines.push('| Result | File | Run |', '|---|---|---|');
               for (const r of runs) {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,8 @@ jobs:
               if (fileMatch) currentFile = fileMatch[1];
               if (runMatch && currentFile) runs.push({ file: currentFile, run: runMatch[1], result: runMatch[2] });
             }
-            const lines = [];
+            const logo = '<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/opentofu/brand-artifacts/main/full/transparent/PNG/on-dark.png"><img src="https://raw.githubusercontent.com/opentofu/brand-artifacts/main/full/transparent/PNG/on-light.png" height="24"></picture>';
+            const lines = [logo, ''];
             if (runs.length) {
               lines.push('| Result | File | Run |', '|---|---|---|');
               for (const r of runs) {

--- a/tests/plan-and-apply/main.tofu
+++ b/tests/plan-and-apply/main.tofu
@@ -17,13 +17,13 @@ module "google_storage_bucket" {
 # https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/id
 
 resource "random_id" "test" {
-  byte_length = 6
+  byte_length = 4
 }
 
 # Random String Resource
 # https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/string
 
 resource "random_string" "test" {
-  length  = 8
+  length  = 4
   special = false
 }

--- a/tests/plan-and-apply/main.tofu
+++ b/tests/plan-and-apply/main.tofu
@@ -17,13 +17,13 @@ module "google_storage_bucket" {
 # https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/id
 
 resource "random_id" "test" {
-  byte_length = 4
+  byte_length = 3
 }
 
 # Random String Resource
 # https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/string
 
 resource "random_string" "test" {
-  length  = 8
+  length  = 4
   special = false
 }

--- a/tests/plan-and-apply/main.tofu
+++ b/tests/plan-and-apply/main.tofu
@@ -17,13 +17,13 @@ module "google_storage_bucket" {
 # https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/id
 
 resource "random_id" "test" {
-  byte_length = 3
+  byte_length = 6
 }
 
 # Random String Resource
 # https://search.opentofu.org/provider/hashicorp/random/latest/docs/resources/string
 
 resource "random_string" "test" {
-  length  = 4
+  length  = 8
   special = false
 }


### PR DESCRIPTION
## Summary

The plan job summary was too verbose — it rendered a per-resource table listing every individual resource being added/changed/destroyed, plus an "Output changes" table. For large repos with many resources across multiple regional jobs this created a lot of noise on the summary page.

## Changes

Replace the per-resource table and output-changes section in the **plan** summary with a single bolded totals line:

> **Plan: 3 to add, 1 to change, 0 to destroy**

The collapsible `<details>Full Plan Output</details>` block is retained for drill-down.

The **apply** summary is unchanged (per-resource rows with durations and statuses remain useful).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified CI summary output for OpenTofu plan/apply/test workflows.
  * Plan summaries now show a compact add/change/destroy table when counts are detected; full plan output remains available as fallback.
  * Apply summaries emit a compact success/failure line, render Outputs without prior escaping, and now start with the OpenTofu logo.

* **Tests**
  * Shortened random string length in test fixtures to speed up and shrink test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-techne-opentofu-workflows/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->