### PR TITLE
Handle multi-line outputs in apply job summary

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,4 +5,3 @@ Reusable GitHub Actions called workflows for OpenTofu deployments across all pla
 ## README Badges
 
 The platform README badge convention says to add an "OpenTofu Tests" badge whenever a `test.yml` workflow exists. This repo intentionally **does not** include that badge: `test.yml` here is a reusable called workflow consumed by other repos (the `tofu test` runner), not a local CI test of this repo. Its run history reflects callers, not this repo, so the badge would be misleading.
-

--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -275,19 +275,33 @@ jobs:
             }
             const outputsStart = output.indexOf('\nOutputs:\n');
             if (outputsStart !== -1) {
+              const outputLines = output.slice(outputsStart + '\nOutputs:\n'.length).trim().split('\n');
               const outputEntries = [];
-              for (const line of output.slice(outputsStart + '\nOutputs:\n'.length).trim().split('\n')) {
-                const m = line.match(/^(\S+)\s*=\s*(.+)$/);
-                if (m) outputEntries.push({ name: m[1], value: m[2].trim() });
-              }
-              if (outputEntries.length) {
-                lines.push('**Outputs**', '', '| Name | Value |', '|---|---|');
-                for (const { name, value } of outputEntries) {
-                  lines.push(`| \`${name}\` | \`${value}\` |`);
+              let current = null;
+              for (const line of outputLines) {
+                const m = line.match(/^(\S+)\s*=\s*(.*)$/);
+                if (m) {
+                  if (current) outputEntries.push(current);
+                  current = { name: m[1], lines: [m[2]] };
+                } else if (current) {
+                  current.lines.push(line);
                 }
-                lines.push('');
+              }
+              if (current) outputEntries.push(current);
+              if (outputEntries.length) {
+                const simple = outputEntries.filter(e => e.lines.length === 1);
+                const complex = outputEntries.filter(e => e.lines.length > 1);
+                if (simple.length) {
+                  lines.push('**Outputs**', '', '| Name | Value |', '|---|---|');
+                  for (const { name, lines: vals } of simple) {
+                    lines.push(`| \`${name}\` | \`${vals[0]}\` |`);
+                  }
+                  lines.push('');
+                }
+                for (const { name, lines: vals } of complex) {
+                  lines.push(`<details>`, `<summary><b>Output:</b> <code>${name}</code></summary>`, '', '```hcl', `${name} = ${vals.join('\n')}`, '```', '', '</details>', '');
+                }
               }
             }
             lines.push('<details>', '<summary>Full Apply Output</summary>', '', '```hcl', output, '```', '', '</details>');
             await core.summary.addRaw(lines.join('\n')).write();
-

--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -282,7 +282,7 @@ jobs:
               const outputEntries = [];
               let current = null;
               for (const line of outputLines) {
-                const m = line.match(/^(\S+)\s*=\s*(.*)$/);
+                const m = line.match(/^([A-Za-z_][A-Za-z0-9_-]*)\s+=\s+(.*)$/);
                 if (m) {
                   if (current) outputEntries.push(current);
                   current = { name: m[1], lines: [m[2]] };

--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -167,12 +167,15 @@ jobs:
             const output = fs.existsSync(outputFile) ? fs.readFileSync(outputFile, 'utf8') : '';
             if (!output.trim()) { return; }
             const planMatch = output.match(/Plan: (\d+) to add, (\d+) to change, (\d+) to destroy/);
+            const outputsOnlyMatch = output.includes('Changes to Outputs:');
             const errorMatch = output.match(/Error:.+/);
             const logo = '<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/opentofu/brand-artifacts/main/full/transparent/PNG/on-dark.png"><img src="https://raw.githubusercontent.com/opentofu/brand-artifacts/main/full/transparent/PNG/on-light.png" height="24"></picture>';
             const lines = [logo, ''];
             if (planMatch) {
               lines.push('| ➕ Add | 🔄 Change | 🗑️ Destroy |', '|---|---|---|');
               lines.push(`| ${planMatch[1]} | ${planMatch[2]} | ${planMatch[3]} |`, '');
+            } else if (outputsOnlyMatch) {
+              lines.push('**📤 Output-only changes.** No infrastructure changes, but output values will be updated.', '');
             } else if (!errorMatch) {
               lines.push('**✅ No changes.** Your infrastructure matches the configuration.', '');
             }


### PR DESCRIPTION
The output parsing regex only matched single-line values, so complex outputs (maps, lists) were displayed as just their opening brace. Now multi-line outputs render in collapsible code blocks while simple scalar outputs remain in the table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified README badge guidance to explain why an “OpenTofu Tests” badge is intentionally omitted.

* **Improvements**
  * CI summaries now detect and label “output-only” plans (no infrastructure changes, only outputs).
  * Apply output display improved: single-line outputs shown in tables; multi-line outputs rendered in expandable sections for easier inspection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-techne-opentofu-workflows/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->