### PR TITLE
Show all outputs in a unified table with expandable details

### DIFF
--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -292,18 +292,17 @@ jobs:
               }
               if (current) outputEntries.push(current);
               if (outputEntries.length) {
-                const simple = outputEntries.filter(e => e.lines.length === 1);
-                const complex = outputEntries.filter(e => e.lines.length > 1);
-                if (simple.length) {
-                  lines.push('**Outputs**', '', '| Name | Value |', '|---|---|');
-                  for (const { name, lines: vals } of simple) {
-                    lines.push(`| \`${name}\` | \`${vals[0]}\` |`);
+                lines.push('**Outputs**', '', '<table>', '<tr><th>Name</th><th>Value</th></tr>');
+                for (const { name, lines: vals } of outputEntries) {
+                  const value = vals.join('\n');
+                  const esc = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+                  if (vals.length === 1) {
+                    lines.push(`<tr><td><code>${name}</code></td><td><code>${esc(value)}</code></td></tr>`);
+                  } else {
+                    lines.push(`<tr><td><code>${name}</code></td><td><details><summary>Show value</summary><pre>${esc(`${name} = ${value}`)}</pre></details></td></tr>`);
                   }
-                  lines.push('');
                 }
-                for (const { name, lines: vals } of complex) {
-                  lines.push(`<details>`, `<summary><b>Output:</b> <code>${name}</code></summary>`, '', '```hcl', `${name} = ${vals.join('\n')}`, '```', '', '</details>', '');
-                }
+                lines.push('</table>', '');
               }
             }
             lines.push('<details>', '<summary>Full Apply Output</summary>', '', '```hcl', output, '```', '', '</details>');

--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -299,7 +299,7 @@ jobs:
                   if (vals.length === 1) {
                     lines.push(`<tr><td><code>${name}</code></td><td><code>${esc(value)}</code></td></tr>`);
                   } else {
-                    lines.push(`<tr><td><code>${name}</code></td><td><details><summary>Show value</summary><pre>${esc(`${name} = ${value}`)}</pre></details></td></tr>`);
+                    lines.push(`<tr><td><code>${name}</code></td><td><details><summary><i>Show value</i></summary><pre>${esc(`${name} = ${value}`)}</pre></details></td></tr>`);
                   }
                 }
                 lines.push('</table>', '');

--- a/tests/plan-and-apply/main.tofu
+++ b/tests/plan-and-apply/main.tofu
@@ -18,6 +18,10 @@ module "google_storage_bucket" {
 
 resource "random_id" "test" {
   byte_length = 4
+
+  keepers = {
+    ts = plantimestamp()
+  }
 }
 
 # Random String Resource

--- a/tests/plan-and-apply/outputs.tofu
+++ b/tests/plan-and-apply/outputs.tofu
@@ -1,4 +1,45 @@
+# Output Values
+# https://opentofu.org/docs/language/values/outputs
+
+output "project_id" {
+  description = "The project ID"
+  value       = var.project
+}
+
 output "random_string" {
   description = "The random string value"
   value       = random_string.test.result
+}
+
+output "sensitive_value" {
+  description = "A sensitive output to verify HTML escaping of <sensitive>"
+  sensitive   = true
+  value       = random_string.test.result
+}
+
+output "simple_map" {
+  description = "A multi-line map output to verify details rendering"
+  value = {
+    environment = module.core_helpers.environment
+    env         = module.core_helpers.env
+    project_id  = var.project
+    region      = "us-east1"
+  }
+}
+
+output "nested_object" {
+  description = "A nested object output to verify complex details rendering"
+  value = {
+    cluster = {
+      name     = "test-cluster"
+      location = "us-east1-b"
+      node_pools = {
+        default = {
+          machine_type   = "e2-standard-2"
+          min_node_count = 1
+          max_node_count = 3
+        }
+      }
+    }
+  }
 }

--- a/tests/plan-and-apply/outputs.tofu
+++ b/tests/plan-and-apply/outputs.tofu
@@ -14,16 +14,17 @@ output "random_string" {
 output "sensitive_value" {
   description = "A sensitive output to verify HTML escaping of <sensitive>"
   sensitive   = true
-  value       = random_string.test.result
+  value       = plantimestamp()
 }
 
 output "simple_map" {
   description = "A multi-line map output to verify details rendering"
   value = {
-    environment = module.core_helpers.environment
-    env         = module.core_helpers.env
-    project_id  = var.project
-    region      = "us-east1"
+    environment  = module.core_helpers.environment
+    env          = module.core_helpers.env
+    project_id   = var.project
+    region       = "us-east1"
+    last_applied = plantimestamp()
   }
 }
 
@@ -41,5 +42,6 @@ output "nested_object" {
         }
       }
     }
+    last_applied = plantimestamp()
   }
 }


### PR DESCRIPTION
Consolidates the apply job summary outputs into a single HTML table instead of splitting simple outputs into a markdown table and complex outputs into separate `<details>` blocks.

**Before:** Simple outputs in a markdown table, complex outputs as standalone collapsible sections below.

**After:** All outputs in one HTML `<table>`. Simple values display inline in `<code>` tags. Complex (multi-line) values use a collapsible `<details>` element within the table cell. All values are HTML-escaped to safely render tokens like `<sensitive>`.

Example rendering:

| Name | Value |
|---|---|
| `project_id` | `"pt-pneuma-tf10-sb"` |
| `gateway_dns` | ▶ Show value (expandable) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved formatting of OpenTofu/Terraform outputs in GitHub workflow summaries — outputs now render as an HTML table with collapsible sections for multi-line values, improving readability.
* **New Features**
  * Summaries now include a broader set of outputs (including sensitive-marked, mapped, and nested values) for richer result visibility.
  * Test configuration updated to tie a generated identifier to a timestamp for more deterministic keeper behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-techne-opentofu-workflows/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->