### PR TITLE
Add optional TF_VAR injection and passthrough output to plan-and-apply

### DIFF
--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -24,6 +24,11 @@ on:
         description: "The GCS bucket used for OpenTofu state storage"
         required: true
         type: string
+      opentofu_var_json:
+        description: "JSON object of extra OpenTofu variables to inject; each top-level key becomes TF_VAR_<key> (value JSON-encoded)"
+        required: false
+        type: string
+        default: ""
       opentofu_version:
         description: "The version of OpenTofu to use"
         required: true
@@ -32,6 +37,11 @@ on:
         description: "The OpenTofu workspace to select"
         required: true
         type: string
+      passthrough_output:
+        description: "Name of a tofu output to expose as this workflow's `passthrough` output (JSON-encoded)"
+        required: false
+        type: string
+        default: ""
       service_account:
         description: "The GCP service account to impersonate for the deployment"
         required: true
@@ -55,6 +65,11 @@ on:
       opentofu_plan_secret_args:
         description: "Additional secret arguments to pass to the tofu plan command"
         required: false
+
+    outputs:
+      passthrough:
+        description: "JSON-encoded value of the tofu output named by passthrough_output (empty if unset or absent from state)"
+        value: ${{ jobs.plan.outputs.passthrough }}
 
 permissions:
   contents: read
@@ -133,12 +148,28 @@ jobs:
       - name: OpenTofu format
         run: tofu fmt -check -diff
 
+      - name: Inject OpenTofu variables
+        if: inputs.opentofu_var_json != ''
+        env:
+          OPENTOFU_VAR_JSON: ${{ inputs.opentofu_var_json }}
+        run: >-
+          echo "$OPENTOFU_VAR_JSON"
+          | jq -r 'to_entries[] | "TF_VAR_\(.key)=\(.value | tojson)"'
+          >> "$GITHUB_ENV"
+
       - name: OpenTofu initialize
         run: tofu init
 
       - name: OpenTofu workspace
         run: >-
           tofu workspace select -or-create ${{ inputs.opentofu_workspace }}
+
+      - name: OpenTofu passthrough output
+        id: passthrough
+        if: inputs.passthrough_output != ''
+        run: >-
+          echo "value=$(tofu output -json ${{ inputs.passthrough_output }}
+          2>/dev/null | jq -c . || echo '')" >> "$GITHUB_OUTPUT"
 
       - name: OpenTofu validate
         run: tofu validate
@@ -185,6 +216,7 @@ jobs:
 
     outputs:
       plan-exit-code: ${{ steps.plan.outputs.exitcode }}
+      passthrough: ${{ steps.passthrough.outputs.value }}
 
   apply:
     name: OpenTofu apply
@@ -247,6 +279,15 @@ jobs:
         uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2.0.2
         with:
           tofu_version: ${{ inputs.opentofu_version }}
+
+      - name: Inject OpenTofu variables
+        if: inputs.opentofu_var_json != ''
+        env:
+          OPENTOFU_VAR_JSON: ${{ inputs.opentofu_var_json }}
+        run: >-
+          echo "$OPENTOFU_VAR_JSON"
+          | jq -r 'to_entries[] | "TF_VAR_\(.key)=\(.value | tojson)"'
+          >> "$GITHUB_ENV"
 
       - name: OpenTofu apply
         id: apply

--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -161,14 +161,18 @@ jobs:
         run: tofu init
 
       - name: OpenTofu workspace
+        env:
+          OPENTOFU_WORKSPACE: ${{ inputs.opentofu_workspace }}
         run: >-
-          tofu workspace select -or-create ${{ inputs.opentofu_workspace }}
+          tofu workspace select -or-create "$OPENTOFU_WORKSPACE"
 
       - name: OpenTofu passthrough output
         id: passthrough
         if: inputs.passthrough_output != ''
+        env:
+          PASSTHROUGH_OUTPUT: ${{ inputs.passthrough_output }}
         run: >-
-          echo "value=$(tofu output -json ${{ inputs.passthrough_output }}
+          echo "value=$(tofu output -json "$PASSTHROUGH_OUTPUT"
           2>/dev/null | jq -c . || echo '')" >> "$GITHUB_OUTPUT"
 
       - name: OpenTofu validate
@@ -279,15 +283,6 @@ jobs:
         uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2.0.2
         with:
           tofu_version: ${{ inputs.opentofu_version }}
-
-      - name: Inject OpenTofu variables
-        if: inputs.opentofu_var_json != ''
-        env:
-          OPENTOFU_VAR_JSON: ${{ inputs.opentofu_var_json }}
-        run: >-
-          echo "$OPENTOFU_VAR_JSON"
-          | jq -r 'to_entries[] | "TF_VAR_\(.key)=\(.value | tojson)"'
-          >> "$GITHUB_ENV"
 
       - name: OpenTofu apply
         id: apply


### PR DESCRIPTION
## What & why

Adds two **optional, backward-compatible** capabilities to the `plan-and-apply.yml` reusable workflow so a caller can chain state between workspaces without granting cross-repo state access:

- **`opentofu_var_json`** (input) — a JSON object of extra OpenTofu variables. Each top-level key becomes `TF_VAR_<key>` (value JSON-encoded) and is exported before `init`/`plan` **and** before `apply` (providers re-configure at apply time).
- **`passthrough_output`** (input) + **`passthrough`** (workflow output) — names a `tofu output` to expose as the workflow's `passthrough` output (JSON-encoded, compact), read in the plan job so it is always available regardless of whether `apply` runs.

## Why this exists

pt-pneuma is moving to a team-based cluster model where the platform team provisions namespaces + add-ons across every team's clusters. Each per-zone Kubernetes provider must iterate the cluster set, but **OpenTofu provider `for_each` requires a static context** — it accepts input variables but rejects module outputs and `terraform_remote_state`. So pt-pneuma's main workspace emits its cluster set as an output, and downstream zone jobs receive it via `opentofu_var_json` → `TF_VAR_clusters`. Logos remains the single source of truth.

## Backward compatibility

Both inputs default to `""` and their steps are gated by `if: ... != ''`, so existing callers are unaffected. The new workflow output is optional and empty when unused.

## Notes

- Emitting `passthrough` from the plan job (post-`init`, reads committed state) means a brand-new team's clusters lag by one run before downstream jobs see them — safe, avoids connecting to a just-created cluster in the same run.

Consumed by: osinfra-io/pt-pneuma#134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for passing structured variables into infrastructure runs via an optional JSON input.
  * Added an optional workflow output that can return a selected Terraform output from the plan stage.

* **Enhancements**
  * When configured, top-level JSON keys are forwarded as environment variables for planning (and applying, if used).
  * When enabled, the selected output is captured during planning and exposed to later steps/workflow outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->