### PR TITLE
Fix missing pipefail on apply and show steps

### DIFF
--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -189,7 +189,9 @@ jobs:
 
       - name: OpenTofu show
         id: show
-        run: tofu show -no-color plan.out | tee "$RUNNER_TEMP/tofu-show.txt"
+        run: |
+          set -o pipefail
+          tofu show -no-color plan.out | tee "$RUNNER_TEMP/tofu-show.txt"
 
       - name: OpenTofu summary
         if: always()
@@ -286,7 +288,9 @@ jobs:
 
       - name: OpenTofu apply
         id: apply
-        run: tofu apply -no-color plan.out 2>&1 | tee "$RUNNER_TEMP/tofu-apply.txt"
+        run: |
+          set -o pipefail
+          tofu apply -no-color plan.out 2>&1 | tee "$RUNNER_TEMP/tofu-apply.txt"
 
       - name: OpenTofu summary
         if: always()

--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -144,8 +144,7 @@ jobs:
         uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2.0.2
         with:
           tofu_version: ${{ inputs.opentofu_version }}
-
-      - name: OpenTofu format
+          tofu_wrapper: false
         run: tofu fmt -check -diff
 
       - name: Inject OpenTofu variables
@@ -285,6 +284,7 @@ jobs:
         uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2.0.2
         with:
           tofu_version: ${{ inputs.opentofu_version }}
+          tofu_wrapper: false
 
       - name: OpenTofu apply
         id: apply


### PR DESCRIPTION
Without `set -o pipefail`, the pipeline exit code is `tee`'s (always 0), not `tofu`'s. A failed `tofu apply` or `tofu show` silently passes the step and the job reports success.\n\nFixes the `OpenTofu show` and `OpenTofu apply` steps in `plan-and-apply.yml`.

Closes #244

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of infrastructure plan/apply execution by ensuring errors in the command/output pipeline are detected and surfaced immediately.
  * Updated infrastructure execution setup to use a more direct OpenTofu invocation approach, reducing the chance of failures being masked during output capture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->