### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -184,17 +184,19 @@ jobs:
         env:
           OPENTOFU_PLAN_ARGS: ${{ inputs.opentofu_plan_args }}
           OPENTOFU_PLAN_SECRET_ARGS: ${{ secrets.opentofu_plan_secret_args }}
+        shell: bash
         run: |
           set +e
           tofu plan -detailed-exitcode -input=false -out=plan.out $OPENTOFU_PLAN_ARGS $OPENTOFU_PLAN_SECRET_ARGS
-          exit_code=$?
-          [[ $exit_code -eq 0 || $exit_code -eq 2 ]]
+          exitcode=$?
+          echo "exitcode=${exitcode}" >> $GITHUB_OUTPUT
+          if [ $exitcode -eq 1 ]; then
+            exit 1
+          fi
 
       - name: OpenTofu show
         id: show
-        run: |
-          set -o pipefail
-          tofu show -no-color plan.out | tee "$RUNNER_TEMP/tofu-show.txt"
+        run: tofu show -no-color plan.out | tee "$RUNNER_TEMP/tofu-show.txt"
 
       - name: OpenTofu summary
         if: always()
@@ -230,7 +232,7 @@ jobs:
   apply:
     name: OpenTofu apply
     needs: plan
-    if: needs.plan.outputs.plan-exit-code == 2
+    if: needs.plan.outputs.plan-exit-code == '2'
     runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.github_environment }}
@@ -292,6 +294,7 @@ jobs:
 
       - name: OpenTofu apply
         id: apply
+        shell: bash
         run: |
           set -o pipefail
           tofu apply -no-color plan.out 2>&1 | tee "$RUNNER_TEMP/tofu-apply.txt"

--- a/.github/workflows/plan-and-apply.yml
+++ b/.github/workflows/plan-and-apply.yml
@@ -184,9 +184,11 @@ jobs:
         env:
           OPENTOFU_PLAN_ARGS: ${{ inputs.opentofu_plan_args }}
           OPENTOFU_PLAN_SECRET_ARGS: ${{ secrets.opentofu_plan_secret_args }}
-        run: >-
-          tofu plan -detailed-exitcode -input=false -out=plan.out
-          $OPENTOFU_PLAN_ARGS $OPENTOFU_PLAN_SECRET_ARGS
+        run: |
+          set +e
+          tofu plan -detailed-exitcode -input=false -out=plan.out $OPENTOFU_PLAN_ARGS $OPENTOFU_PLAN_SECRET_ARGS
+          exit_code=$?
+          [[ $exit_code -eq 0 || $exit_code -eq 2 ]]
 
       - name: OpenTofu show
         id: show

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: "Release"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release create "$TAG" \
+            --repo "${{ github.repository }}" \
+            --title "$TAG" \
+            --generate-notes


### PR DESCRIPTION
Adds the standard release workflow that auto-generates release notes when a semver tag is pushed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated release workflow that creates GitHub releases when a version tag is pushed.
  * Release notes are generated automatically, using the tag as the release title.
  * Improved plan-and-apply behavior to correctly handle OpenTofu plan exit codes and fail safely on unexpected results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->